### PR TITLE
Add badges for Travis CI and CodeCov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/gap-packages/tomlib.svg?branch=master)](https://travis-ci.org/gap-packages/tomlib)
+[![Code Coverage](https://codecov.io/github/gap-packages/tomlib/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/tomlib)
+
 The GAP Library of Tables of Marks
 ==================================
 


### PR DESCRIPTION
With this PR, you will be able to display the status of tests on the README file and quickly navigate to the tests output by clicking on these badges.

(there is no need to make a release for that, this can stay till the next time to be combined with some other changes).